### PR TITLE
Fix of parse the secure flag

### DIFF
--- a/src/CookieFile.php
+++ b/src/CookieFile.php
@@ -65,7 +65,7 @@ class CookieFile
             $cookies[] = new Cookie($cookieData[5], $cookieData[6], [
                 'domain' => $cookieData[0],
                 'path'   => $cookieData[2],
-                'secure' => $cookieData[3] == true,
+                'secure' => $cookieData[3] == 'TRUE',
                 'expire' => $cookieData[4],
                 'http_only' => $httpOnly,
             ]);


### PR DESCRIPTION
The secure flag is always parsed as TRUE.
